### PR TITLE
Remove non-standard arbitrary-utf8-data feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ The API is still work in progress so the minor version should be specified.
 These features are by default turned *OFF*.
 - `extended-error` - Allows extended error messages of the form `<error code>, "error message;extended message"`.
 Requires more data and program memory.
-- `arbitrary-utf8-string` - Allows UTF8 arbitrary data block, `#s"Detta är en utf8 sträng med roliga bokstäver`.
-Checked by the parser and emits a InvalidBlockData if the UTF8 data is malformed. **This is not a part of the SCPI standard**
-- `use_libm` - Uses libm for math operations instead of intrinsics on target which does not support them. **Use this if you get linker errors about round/roundf**
+- `std` - Use std library, note that libm feature can be disabled with std.
 
 These features are by default turned **ON**.
+- `libm` - Uses libm for no_std operation on stable no_std.
 - `build-info` - Includes build info in the library and creates a `LIBrary[:VERsion]?` command macro to query it.
 - `unit-*` - Creates conversion from a argument \[and suffix] into corresponding [uom](https://crates.io/crates/uom) unit. Disable the ones you don't need to save space and skip uom.
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -23,4 +23,3 @@ path = "src/bench.rs"
 default = []
 no_std = ["scpi/libm"]
 extended-error = ["scpi/extended-error"]
-arbitrary-utf8-string = ["scpi/arbitrary-utf8-string"]

--- a/scpi/Cargo.toml
+++ b/scpi/Cargo.toml
@@ -79,9 +79,6 @@ libm = ["lexical-core/libm"]
 # Support extender errors (example -100,"Command error;extended")
 extended-error = []
 
-# Support UTF8 arbitrarydata block #s'utf8-data'
-arbitrary-utf8-string = []
-
 # Include build info
 build-info = []
 

--- a/scpi/src/lib.rs
+++ b/scpi/src/lib.rs
@@ -32,12 +32,10 @@
 //! These features are by default turned *OFF*.
 //! - `extended-error` - Allows extended error messages of the form `<error code>, "error message;extended message"`.
 //! Requires more data and program memory.
-//! - `arbitrary-utf8-string` - Allows UTF8 arbitrary data block, `#s"Detta är en utf8 sträng med roliga bokstäver`.
-//! Checked by the parser and emits a InvalidBlockData if the UTF8 data is malformed. **This is not a part of the SCPI standard**
 //! - `std` - Use std library, note that libm feature can be disabled with std.
 //!
 //! These features are by default turned **ON**.
-//! - `libm` - Uses libm for no_std operation on stable.
+//! - `libm` - Uses libm for no_std operation on stable no_std.
 //! - `build-info` - Includes build info in the library and creates a `LIBrary[:VERsion]?` command macro to query it.
 //! - `unit-*` - Creates conversion from a argument \[and suffix] into corresponding [uom](https://crates.io/crates/uom) unit. Disable the ones you don't need to save space and skip uom.
 //!

--- a/scpi/src/tokenizer.rs
+++ b/scpi/src/tokenizer.rs
@@ -793,8 +793,7 @@ impl<'a> Tokenizer<'a> {
             }
 
             let payload_len = lexical_core::parse::<usize>(
-                &self
-                    .chars
+                self.chars
                     .as_slice()
                     .get(..len as usize)
                     .ok_or(ErrorCode::InvalidBlockData)?,

--- a/scpi/src/tokenizer.rs
+++ b/scpi/src/tokenizer.rs
@@ -42,8 +42,6 @@ pub enum Token<'a> {
     ArbitraryBlockData(&'a [u8]),
     /// A <EXPRESSION PROGRAM DATA> 7.7.7
     ExpressionProgramData(&'a [u8]),
-    /// Non-standard UTF8 data
-    Utf8BlockData(&'a str),
 }
 
 impl<'a> Token<'a> {
@@ -57,7 +55,6 @@ impl<'a> Token<'a> {
                 | Self::StringProgramData(_)
                 | Self::ArbitraryBlockData(_)
                 | Self::ExpressionProgramData(_)
-                | Self::Utf8BlockData(_)
         )
     }
 
@@ -242,7 +239,6 @@ impl<'a> TryFrom<Token<'a>> for &'a str {
             Token::StringProgramData(s) | Token::ArbitraryBlockData(s) => {
                 str::from_utf8(s).map_err(|_| ErrorCode::StringDataError.into())
             }
-            Token::Utf8BlockData(s) => Ok(s),
             t => {
                 if t.is_data() {
                     Err(ErrorCode::DataTypeError.into())
@@ -823,30 +819,6 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
-    /// <ARBITRARY DATA PROGRAM DATA>
-    /// Non standard custom arbitrary data block format #s"..."/#s'...'
-    /// The parser will automatically check and convert the data to a UTF8 string, emitting
-    /// a InvalidBlockData error if the string is not valid UTF8.
-    #[cfg(feature = "arbitrary-utf8-string")]
-    fn read_utf8_data(&mut self, _format: u8) -> Result<Token<'a>, ErrorCode> {
-        if let Some(x) = self.chars.clone().next() {
-            if *x != b'"' && *x != b'\'' {
-                return Err(ErrorCode::NoError);
-            }
-            if let Token::StringProgramData(s) = self.read_string_data(*x, false)? {
-                if let Ok(u) = str::from_utf8(s) {
-                    Ok(Token::Utf8BlockData(u))
-                } else {
-                    Err(ErrorCode::InvalidBlockData)
-                }
-            } else {
-                Err(ErrorCode::InvalidBlockData)
-            }
-        } else {
-            Err(ErrorCode::InvalidBlockData)
-        }
-    }
-
     /// <EXPRESSION PROGRAM DATA>
     /// See IEEE 488.2-1992 7.7.7
     ///
@@ -1106,33 +1078,6 @@ mod test_parse {
         );
     }
 
-    #[cfg(feature = "arbitrary-utf8-string")]
-    #[test]
-    fn test_read_arb_utf8() {
-        assert_eq!(
-            Tokenizer::new("'åäö'".as_bytes()).read_utf8_data(b's'),
-            Ok(Token::Utf8BlockData("åäö"))
-        );
-        assert_eq!(
-            Tokenizer::new("\"åäö\"".as_bytes()).read_utf8_data(b's'),
-            Ok(Token::Utf8BlockData("åäö"))
-        );
-        assert_eq!(
-            Tokenizer::new("'å''äö'".as_bytes()).read_utf8_data(b's'),
-            Ok(Token::Utf8BlockData("å''äö"))
-        );
-        //Missing quote
-        assert_eq!(
-            Tokenizer::new("'å''äö".as_bytes()).read_utf8_data(b's'),
-            Err(ErrorCode::InvalidStringData)
-        );
-        //Invalid utf8
-        assert_eq!(
-            Tokenizer::new(b"'\xff'").read_utf8_data(b's'),
-            Err(ErrorCode::InvalidBlockData)
-        );
-    }
-
     #[test]
     fn test_read_expr_data() {
         assert_eq!(
@@ -1260,8 +1205,6 @@ impl<'a> Iterator for Tokenizer<'a> {
                 } else if let Some(x) = self.chars.next() {
                     Some(match x {
                         /* Arbitrary block */
-                        #[cfg(feature = "arbitrary-utf8-string")]
-                        x if *x == b's' => self.read_utf8_data(*x),
                         x if x.is_ascii_digit() => self.read_arbitrary_data(*x),
                         /*Non-decimal numeric*/
                         _ => self.read_nondecimal_data(*x),


### PR DESCRIPTION
Not used and doesn't exist in the SCPI-99 standard. Remove completely.

UTF8 strings can still be parsed from ASCII strings or arbitrary data blocks.