### PR TITLE
Remove build-info feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ These features are by default turned *OFF*.
 Requires more data and program memory.
 - `arbitrary-utf8-string` - Allows UTF8 arbitrary data block, `#s"Detta är en utf8 sträng med roliga bokstäver`.
 Checked by the parser and emits a InvalidBlockData if the UTF8 data is malformed. **This is not a part of the SCPI standard**
-- `use_libm` - Uses libm for math operations instead of intrinsics on target which does not support them. **Use this if you get linker errors about round/roundf**
+- `std` - Use std library, note that libm feature can be disabled with std.
 
 These features are by default turned **ON**.
-- `build-info` - Includes build info in the library and creates a `LIBrary[:VERsion]?` command macro to query it.
+- `libm` - Uses libm for no_std operation on stable.
 - `unit-*` - Creates conversion from a argument \[and suffix] into corresponding [uom](https://crates.io/crates/uom) unit. Disable the ones you don't need to save space and skip uom.
 
 ## Getting started

--- a/example/src/common.rs
+++ b/example/src/common.rs
@@ -23,7 +23,6 @@ use scpi::{
     nquery,
     //Helpers
     qonly,
-    scpi_crate_version,
     scpi_status,
     scpi_system,
     scpi_tree,
@@ -469,8 +468,6 @@ pub const TREE: &Node = scpi_tree![
     scpi_status!(),
     // Create default SCPI mandated SYSTem subsystem
     scpi_system!(),
-    //
-    scpi_crate_version!(),
     //Test
     Node {
         name: b"ABORt",

--- a/scpi/Cargo.toml
+++ b/scpi/Cargo.toml
@@ -14,8 +14,6 @@ documentation = "https://docs.rs/crate/scpi"
 repository = "https://github.com/Atmelfan/scpi-rs"
 readme = "README.md"
 
-build = "build.rs"
-
 [badges]
 maintenance = { status = "actively-developed" }
 
@@ -37,13 +35,8 @@ features = [
     "try-from"
 ]
 
-[build-dependencies]
-built = { version = "0.5", features = ["git2", "semver"] }
-
 [features]
 default = [
-    # Library build information
-    "build-info",
     # Use libm in order to build on stable
     "libm",
     # Units
@@ -81,9 +74,6 @@ extended-error = []
 
 # Support UTF8 arbitrarydata block #s'utf8-data'
 arbitrary-utf8-string = []
-
-# Include build info
-build-info = []
 
 ###################################### UNITS ######################################
 # Individual units

--- a/scpi/build.rs
+++ b/scpi/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    built::write_built_file().expect("Failed to acquire build-time information");
-}

--- a/scpi/src/tokenizer.rs
+++ b/scpi/src/tokenizer.rs
@@ -797,8 +797,7 @@ impl<'a> Tokenizer<'a> {
             }
 
             let payload_len = lexical_core::parse::<usize>(
-                &self
-                    .chars
+                self.chars
                     .as_slice()
                     .get(..len as usize)
                     .ok_or(ErrorCode::InvalidBlockData)?,


### PR DESCRIPTION
Remove build info feature. This is a unnecessary feature and makes reproducible builds harder.