### PR TITLE
Update CI/CD workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,14 +21,15 @@ jobs:
 
       - name: Install Tarpaulin
         run: |
-          cargo install cargo-tarpaulin
+          cargo install cargo-cov
 
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+          cargo cov --all-features
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           # token: ${{secrets.CODECOV_TOKEN}} # not required for public repos
+          flags: unittests
           fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install Tarpaulin
+      - name: Install cargo-cov
         run: |
           cargo install cargo-cov
 
       - name: Generate code coverage
         run: |
-          cargo cov --all-features
+          cargo cov test --all-features
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,11 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install Tarpaulin
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install Tarpaulin
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,18 +18,17 @@ jobs:
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
-
-      - name: Install cargo-cov
-        run: |
-          cargo install cargo-cov
-
+      
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      
       - name: Generate code coverage
-        run: |
-          cargo cov test --all-features
-
-      - name: Upload to codecov.io
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+    
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          # token: ${{secrets.CODECOV_TOKEN}} # not required for public repos
+          #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          files: lcov.info
           flags: unittests
           fail_ci_if_error: true

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -38,3 +38,14 @@ jobs:
         with:
           name: fuzz_target_1
           path: scpi/fuzz/artifacts/${{ matrix.fuzz-targets }}/*
+        
+      - name: Generate coverage data
+        run: cargo fuzz coverage ${{ matrix.fuzz-targets }}
+      
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          # token: ${{secrets.CODECOV_TOKEN}} # not required for public repos
+          flags: fuzzing-${{ matrix.fuzz-targets }}
+          files: scpi/fuzz/artifacts/${{ matrix.fuzz-targets }}/*
+          fail_ci_if_error: true

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -27,7 +27,10 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz && cargo install cargo-binutils
+        run: cargo install cargo-fuzz
+      
+      - name: Install llvm-tools-preview
+        run: rustup toolchain install nightly --component llvm-tools-preview
 
       - name: Fuzz ${{ matrix.fuzz-targets }}
         run: |

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -27,7 +27,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo install cargo-fuzz && cargo install cargo-binutils
 
       - name: Fuzz ${{ matrix.fuzz-targets }}
         run: |

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Fuzz ${{ matrix.fuzz-targets }}
         run: |
-          cd scpi && cargo +nightly fuzz run ${{ matrix.fuzz-targets }} -- -max_total_time=300
+          cd scpi && cargo fuzz run ${{ matrix.fuzz-targets }} -- -max_total_time=300
 
       - name: Upload failing inputs for Tokenizer
         uses: actions/upload-artifact@v2
@@ -40,7 +40,7 @@ jobs:
           path: scpi/fuzz/artifacts/${{ matrix.fuzz-targets }}/*
         
       - name: Generate coverage data
-        run: cargo fuzz coverage ${{ matrix.fuzz-targets }}
+        run: cd scpi && cargo fuzz coverage ${{ matrix.fuzz-targets }}
       
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -24,15 +24,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install fuzz
-        run: |
-          cargo install cargo-fuzz
+        run: cargo install cargo-fuzz
 
       - name: Fuzz ${{ matrix.fuzz-targets }}
         run: |

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install fuzz
+      - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 
       - name: Fuzz ${{ matrix.fuzz-targets }}
@@ -47,5 +47,5 @@ jobs:
         with:
           # token: ${{secrets.CODECOV_TOKEN}} # not required for public repos
           flags: fuzzing-${{ matrix.fuzz-targets }}
-          files: scpi/fuzz/artifacts/${{ matrix.fuzz-targets }}/*
+          files: scpi/fuzz/coverage/${{ matrix.fuzz-targets }}/*
           fail_ci_if_error: true

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install fuzz
         run: cargo install cargo-fuzz

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -47,7 +47,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo test
-        run: cargo test --no-default-features
+        run: cargo test
 
       - name: Run cargo test with all features
         run: cargo test --all-features

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -41,7 +41,7 @@ jobs:
           - thumbv7em-none-eabihf
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -47,7 +47,7 @@ jobs:
           - thumbv7em-none-eabihf
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -22,16 +22,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   test:
     name: Test Suite
@@ -50,22 +44,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test --no-default-features
 
       - name: Run cargo test with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features
 
   lints:
     name: Lints
@@ -75,21 +60,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -32,7 +32,7 @@ jobs:
           - thumbv7em-none-eabihf
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: get_version
         uses: battila7/get-version-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -38,7 +38,7 @@ jobs:
           - thumbv7em-none-eabihf
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: get_version
         uses: battila7/get-version-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run cargo test with no features
-        run: cargo test --no-default-features
+      - name: Run cargo test
+        run: cargo test
 
       - name: Run cargo test with all features
         run: cargo test --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   test:
     name: Test Suite
@@ -41,22 +35,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - name: Run cargo test with no features
+        run: cargo test --no-default-features
 
       - name: Run cargo test with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features
   
   lints:
     name: Lints
@@ -66,18 +51,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
   
   publish:
     name: crates.io release
@@ -92,16 +69,10 @@ jobs:
         uses: battila7/get-version-action@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-workspaces
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-workspaces
+        run: cargo install cargo-workspaces
       
       - name: Publish
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 ieee488.2-92.pdf
 scpi-99.pdf
 
+# Coverage
+*.gcda
+*.gcno
+
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,python,rust
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,python,rust
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ scpi-99.pdf
 # Coverage
 *.gcda
 *.gcno
+lcov.info
 
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,python,rust
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,python,rust

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "rust-analyzer.cargo.features": "all"
+    "rust-analyzer.cargo.features": "all",
+    "files.exclude": {
+        "*.gcda": true,
+        "*.gcno": true
+    }
 }


### PR DESCRIPTION
The workflow uses actions/checkout@v2 and action-rs/toolchain@v1, both throws warnings and uses deprecated commands.